### PR TITLE
Add additional logging to debug random halting in simulations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "distribute"
-version = "0.14.1"
+version = "0.14.3"
 dependencies = [
  "base16",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distribute"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ easy to use distributed computing
 
 You will need a recent version of `cargo` and the rust compiler `rustc`. Install instructions are [here](https://www.rust-lang.org/tools/install)
 
-```
+```bash
 cargo install --git "https://github.com/fluid-Dynamics-Group/distribute" --force
 ```
 
@@ -16,7 +16,7 @@ User documentation (which you are most likely interested in) is hosted on github
 
 Developer documentation is built with
 
-```
+```bash
 cargo doc --no-deps --open
 ```
 

--- a/install/update.sh
+++ b/install/update.sh
@@ -3,7 +3,7 @@
 cd ~/distribute
 
 # for fish shell
-set VERSION "0.14.2"
+set VERSION "0.14.3"
 
 git fetch -a
 git checkout release-$VERSION

--- a/install/update.sh
+++ b/install/update.sh
@@ -3,7 +3,7 @@
 cd ~/distribute
 
 # for fish shell
-set VERSION "0.14.1"
+set VERSION "0.14.2"
 
 git fetch -a
 git checkout release-$VERSION

--- a/src/add.rs
+++ b/src/add.rs
@@ -6,7 +6,7 @@ pub async fn add(args: cli::Add) -> Result<(), Error> {
     //
     // load the config files
     //
-    let config = config::load_config::<config::Jobs<config::common::File>>(&args.jobs)?;
+    let config = config::load_config::<config::Jobs<config::common::File>>(&args.jobs, true)?;
 
     if config.len_jobs() == 0 {
         return Err(Error::Add(error::AddError::NoJobsToAdd));

--- a/src/add.rs
+++ b/src/add.rs
@@ -96,6 +96,10 @@ pub async fn add(args: cli::Add) -> Result<(), Error> {
 
     let extra = protocol::send_files::FlatFileList {
         files: hashed_files_to_send,
+        node_meta: server::pool_data::NodeMetadata {
+            node_name: "SERVER".into(),
+            node_address: addr,
+        },
     };
     let state = protocol::send_files::SenderState { conn, extra };
     let machine = protocol::Machine::from_state(state);

--- a/src/config/apptainer.rs
+++ b/src/config/apptainer.rs
@@ -18,7 +18,7 @@ use getset::Getters;
 #[serde(deny_unknown_fields)]
 /// initialization and job specification for apptainer job batches
 pub struct Description<FILE> {
-    #[getset(get = "pub(crate)")]
+    #[getset(get = "pub(crate)", get_mut = "pub")]
     /// initialization information on apptainer job
     pub initialize: Initialize<FILE>,
     #[getset(get = "pub(crate)")]

--- a/src/config/common.rs
+++ b/src/config/common.rs
@@ -161,6 +161,7 @@ pub struct HashedFile {
     // on the user's computer, this is a relative path that only contains the hash of the file
     // so that the file will be dumped precisely where we intend it to be dumped on the server
     // through send_files
+    #[getset(get = "pub(crate)")]
     hashed_path: PathBuf,
     // on the user's computer, this is the absolute path to the file
     //
@@ -200,6 +201,7 @@ impl HashedFile {
     }
 
     pub(super) fn delete_at_hashed_path(&self) -> Result<(), std::io::Error> {
+        debug!(hashed_path = %self.hashed_path.display(), original_filename = self.original_filename, "deleting hashed file");
         std::fs::remove_file(&self.hashed_path)?;
 
         Ok(())

--- a/src/config/python.rs
+++ b/src/config/python.rs
@@ -166,7 +166,7 @@ impl Initialize<common::File> {
 
 #[cfg(feature = "cli")]
 impl Initialize<common::HashedFile> {
-    pub(super) fn sendable_files(&self, is_user: bool, files: &mut Vec<FileMetadata>) {
+    pub(crate) fn sendable_files(&self, is_user: bool, files: &mut Vec<FileMetadata>) {
         files.push(self.python_build_file_path.as_sendable(is_user));
 
         self.required_files

--- a/src/config/requirements.rs
+++ b/src/config/requirements.rs
@@ -13,9 +13,11 @@ use std::fmt;
 ///
 /// ```
 /// use distribute::requirements::Requirements;
+/// use distribute::requirements::JobRequiredCaps;
+///
 /// let job_capabilities = vec!["gpu", "apptainer"];
 ///
-/// let requirements : Requirements = Requirements::from(job_capabilities);
+/// let requirements : Requirements<JobRequiredCaps> = Requirements::from(job_capabilities);
 /// ```
 pub struct Requirements<T> {
     pub(crate) reqs: BTreeSet<Requirement>,

--- a/src/node_status.rs
+++ b/src/node_status.rs
@@ -26,7 +26,7 @@ enum Status {
 
 /// check if nodes are online & what their current version of `distribute` is
 pub async fn node_status(args: cli::NodeStatus) -> Result<(), Error> {
-    let nodes_config = config::load_config::<config::Nodes>(&args.nodes_file)?;
+    let nodes_config = config::load_config::<config::Nodes>(&args.nodes_file, true)?;
 
     let mut results = Vec::new();
 

--- a/src/protocol/built.rs
+++ b/src/protocol/built.rs
@@ -129,12 +129,20 @@ impl Machine<Built, ClientBuiltState> {
             cancel_addr,
             ..
         } = self.state;
+
         debug!("moving client built -> prepare build");
-        #[allow(unused_mut)]
+
         let mut conn = conn.update_state();
 
-        #[cfg(test)]
-        assert!(conn.bytes_left().await == 0);
+        if conn.bytes_left().await != 0 {
+            error!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+            panic!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+        }
+
         super::prepare_build::ClientPrepareBuildState {
             conn,
             working_dir,
@@ -297,8 +305,14 @@ impl Machine<Built, ServerBuiltState> {
         #[allow(unused_mut)]
         let mut conn = conn.update_state();
 
-        #[cfg(test)]
-        assert!(conn.bytes_left().await == 0);
+        if conn.bytes_left().await != 0 {
+            error!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+            panic!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+        }
 
         super::prepare_build::ServerPrepareBuildState { conn, common }
     }

--- a/src/protocol/built.rs
+++ b/src/protocol/built.rs
@@ -133,15 +133,7 @@ impl Machine<Built, ClientBuiltState> {
         debug!("moving client built -> prepare build");
 
         let mut conn = conn.update_state();
-
-        if conn.bytes_left().await != 0 {
-            error!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-            panic!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-        }
+        super::assert_conn_empty(&mut conn).await;
 
         super::prepare_build::ClientPrepareBuildState {
             conn,
@@ -162,11 +154,8 @@ impl Machine<Built, ClientBuiltState> {
         } = self.state;
         debug!("moving client built -> executing");
 
-        #[allow(unused_mut)]
         let mut conn = conn.update_state();
-
-        #[cfg(test)]
-        assert!(conn.bytes_left().await == 0);
+        super::assert_conn_empty(&mut conn).await;
 
         // dump all the files in the ./input directory
         let save_location = working_dir.input_folder();
@@ -302,17 +291,8 @@ impl Machine<Built, ServerBuiltState> {
         );
         let ServerBuiltState { conn, common, .. } = self.state;
 
-        #[allow(unused_mut)]
         let mut conn = conn.update_state();
-
-        if conn.bytes_left().await != 0 {
-            error!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-            panic!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-        }
+        super::assert_conn_empty(&mut conn).await;
 
         super::prepare_build::ServerPrepareBuildState { conn, common }
     }
@@ -334,11 +314,8 @@ impl Machine<Built, ServerBuiltState> {
             job_identifier: _,
         } = self.state;
 
-        #[allow(unused_mut)]
         let mut conn = conn.update_state();
-
-        #[cfg(test)]
-        assert!(conn.bytes_left().await == 0);
+        super::assert_conn_empty(&mut conn).await;
 
         let job_name = run_info.task.name();
 

--- a/src/protocol/compiling.rs
+++ b/src/protocol/compiling.rs
@@ -148,11 +148,9 @@ impl Machine<Building, ClientBuildingState> {
             ..
         } = self.state;
 
-        #[allow(unused_mut)]
         let mut conn = conn.update_state();
 
-        #[cfg(test)]
-        assert!(conn.bytes_left().await == 0);
+        super::assert_conn_empty(&mut conn).await;
 
         super::built::ClientBuiltState {
             conn,
@@ -172,14 +170,7 @@ impl Machine<Building, ClientBuildingState> {
 
         let mut conn = conn.update_state();
 
-        if conn.bytes_left().await != 0 {
-            error!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-            panic!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-        }
+        super::assert_conn_empty(&mut conn).await;
 
         super::prepare_build::ClientPrepareBuildState {
             conn,
@@ -262,11 +253,9 @@ impl Machine<Building, ServerBuildingState> {
             batch_name,
             job_identifier,
         } = self.state;
-        #[allow(unused_mut)]
-        let mut conn = conn.update_state();
 
-        #[cfg(test)]
-        assert!(conn.bytes_left().await == 0);
+        let mut conn = conn.update_state();
+        super::assert_conn_empty(&mut conn).await;
 
         super::built::ServerBuiltState {
             conn,
@@ -287,14 +276,7 @@ impl Machine<Building, ServerBuildingState> {
 
         let mut conn = conn.update_state();
 
-        if conn.bytes_left().await != 0 {
-            error!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-            panic!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-        }
+        super::assert_conn_empty(&mut conn).await;
 
         super::prepare_build::ServerPrepareBuildState { conn, common }
     }

--- a/src/protocol/compiling.rs
+++ b/src/protocol/compiling.rs
@@ -170,11 +170,17 @@ impl Machine<Building, ClientBuildingState> {
             ..
         } = self.state;
 
-        #[allow(unused_mut)]
         let mut conn = conn.update_state();
 
-        #[cfg(test)]
-        assert!(conn.bytes_left().await == 0);
+        if conn.bytes_left().await != 0 {
+            error!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+            panic!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+        }
+
         super::prepare_build::ClientPrepareBuildState {
             conn,
             working_dir,
@@ -279,11 +285,17 @@ impl Machine<Building, ServerBuildingState> {
 
         let ServerBuildingState { conn, common, .. } = self.state;
 
-        #[allow(unused_mut)]
         let mut conn = conn.update_state();
 
-        #[cfg(test)]
-        assert!(conn.bytes_left().await == 0);
+        if conn.bytes_left().await != 0 {
+            error!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+            panic!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+        }
+
         super::prepare_build::ServerPrepareBuildState { conn, common }
     }
 }

--- a/src/protocol/executing.rs
+++ b/src/protocol/executing.rs
@@ -179,11 +179,8 @@ impl Machine<Executing, ClientExecutingState> {
             run_info,
         } = self.state;
 
-        #[allow(unused_mut)]
         let mut conn = conn.update_state();
-
-        #[cfg(test)]
-        assert!(conn.bytes_left().await == 0);
+        super::assert_conn_empty(&mut conn).await;
 
         let job_name = run_info.task.name().to_string();
 
@@ -211,15 +208,7 @@ impl Machine<Executing, ClientExecutingState> {
         debug!("moving client executing -> prepare build");
 
         let mut conn = conn.update_state();
-
-        if conn.bytes_left().await != 0 {
-            error!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-            panic!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-        }
+        super::assert_conn_empty(&mut conn).await;
 
         super::prepare_build::ClientPrepareBuildState {
             conn,
@@ -387,11 +376,8 @@ impl Machine<Executing, ServerExecutingState> {
             run_info,
         } = self.state;
 
-        #[allow(unused_mut)]
         let mut conn = conn.update_state();
-
-        #[cfg(test)]
-        assert!(conn.bytes_left().await == 0);
+        super::assert_conn_empty(&mut conn).await;
 
         let extra = send_files::ReceiverFinalStore { common, run_info };
 
@@ -410,15 +396,7 @@ impl Machine<Executing, ServerExecutingState> {
         let ServerExecutingState { conn, common, .. } = self.state;
 
         let mut conn = conn.update_state();
-
-        if conn.bytes_left().await != 0 {
-            error!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-            panic!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-        }
+        super::assert_conn_empty(&mut conn).await;
 
         super::prepare_build::ServerPrepareBuildState { conn, common }
     }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -107,6 +107,12 @@ impl<StateMarker, T> Machine<StateMarker, transport::Connection<T>> {
     }
 }
 
+impl UninitServer {
+    pub(crate) fn node_meta(&self) -> &pool_data::NodeMetadata {
+        &self.state.common.node_meta
+    }
+}
+
 impl<T> SendFilesServer<T> {
     pub(crate) fn into_connection(self) -> transport::Connection<send_files::ServerMsg> {
         self.state.conn

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -242,3 +242,20 @@ impl Common {
         (tx, common)
     }
 }
+
+#[allow(unused_variables)]
+async fn assert_conn_empty<TX, RX>(conn: &mut transport::Connection<TX>) 
+where
+    TX: Serialize + transport::AssociatedMessage<Receive = RX>,
+    RX: serde::de::DeserializeOwned,
+{
+    #[cfg(test)] 
+    if conn.bytes_left().await != 0 {
+        error!(
+            "connection was not empty - this is guaranteed to cause error in following steps!"
+        );
+        panic!(
+            "connection was not empty - this is guaranteed to cause error in following steps!"
+        );
+    }
+}

--- a/src/protocol/prepare_build.rs
+++ b/src/protocol/prepare_build.rs
@@ -94,11 +94,16 @@ impl Machine<PrepareBuild, ClientPrepareBuildState> {
             cancel_addr,
         } = self.state;
 
-        #[allow(unused_mut)]
         let mut conn = conn.update_state();
 
-        #[cfg(test)]
-        assert!(conn.bytes_left().await == 0);
+        if conn.bytes_left().await != 0 {
+            error!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+            panic!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+        }
 
         // TODO: have better function to generate this signature
         let save_location = working_dir.initial_files_folder();

--- a/src/protocol/send_files/mod.rs
+++ b/src/protocol/send_files/mod.rs
@@ -3,6 +3,7 @@ mod sender;
 
 use super::Machine;
 use crate::prelude::*;
+use crate::server::pool_data::NodeMetadata;
 
 pub(crate) use receiver::{
     BuildingReceiver, ExecutingReceiver, Nothing, ReceiverFinalStore, ReceiverState,
@@ -24,6 +25,14 @@ pub(crate) trait NextState {
     type Marker;
 
     fn next_state(self) -> Self::Next;
+}
+
+pub(crate) trait SendLogging {
+    fn job_identifier(&self) -> JobSetIdentifier;
+    fn namespace(&self) -> &str;
+    fn batch_name(&self) -> &str;
+    fn job_name(&self) -> &str;
+    fn node_meta(&self) -> &NodeMetadata;
 }
 
 #[derive(thiserror::Error, Debug, From)]

--- a/src/protocol/send_files/mod.rs
+++ b/src/protocol/send_files/mod.rs
@@ -140,6 +140,7 @@ async fn transport_files_with_large_file() {
         job_name: "test job name".into(),
         folder_state: client::BindingFolderState::new(),
         cancel_addr,
+        node_meta: NodeMetadata::by_name("SERVER")
     };
 
     let client_state = SenderState {

--- a/src/protocol/send_files/receiver.rs
+++ b/src/protocol/send_files/receiver.rs
@@ -373,15 +373,7 @@ where
                         );
                     }
 
-                    // ensure the connection is empty as we expect it to be
-                    if self.state.conn.bytes_left().await != 0 {
-                        error!(
-                            "connection was not empty - this is guaranteed to cause error in following steps!"
-                        );
-                        panic!(
-                            "connection was not empty - this is guaranteed to cause error in following steps!"
-                        );
-                    }
+                    super::super::assert_conn_empty(&mut self.state.conn).await;
 
                     // we are now done receiving files
                     let built_state = self.state.next_state();

--- a/src/protocol/send_files/sender.rs
+++ b/src/protocol/send_files/sender.rs
@@ -373,14 +373,7 @@ where
         let tmp = self.state.conn.transport_data(&msg).await;
         throw_error_with_self!(tmp, self);
 
-        if self.state.conn.bytes_left().await != 0 {
-            error!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-            panic!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-        }
+        super::super::assert_conn_empty(&mut self.state.conn).await;
 
         let next_state = self.state.next_state();
         let machine = Machine::from_state(next_state);

--- a/src/protocol/send_files/sender.rs
+++ b/src/protocol/send_files/sender.rs
@@ -1,13 +1,16 @@
 use super::Machine;
 use crate::prelude::*;
 
+use crate::server::pool_data::NodeMetadata;
 use client::utils;
 
 use super::super::built::{Built, ClientBuiltState};
 use super::super::uninit::ClientUninitState;
 use super::super::UninitClient;
 use super::super::UninitServer;
-use super::{ClientError, ClientMsg, NextState, SendFiles, ServerMsg, LARGE_FILE_BYTE_THRESHOLD};
+use super::{
+    ClientError, ClientMsg, NextState, SendFiles, SendLogging, ServerMsg, LARGE_FILE_BYTE_THRESHOLD,
+};
 use crate::client::execute::FileMetadata;
 use protocol::uninit::ServerUninitState;
 
@@ -18,7 +21,6 @@ pub(crate) struct SenderState<T> {
 }
 
 pub(crate) trait FileSender {
-    fn job_name(&self) -> &str;
     fn files_to_send(&self) -> Box<dyn Iterator<Item = FileMetadata> + Send>;
 }
 
@@ -28,17 +30,33 @@ pub(crate) struct SenderFinalStore {
     pub(crate) folder_state: client::BindingFolderState,
     pub(crate) cancel_addr: SocketAddr,
     pub(crate) working_dir: WorkingDir,
+    // does not really matter, here for the interface mostly
+    pub(crate) node_meta: NodeMetadata,
 }
 
 impl FileSender for SenderFinalStore {
-    fn job_name(&self) -> &str {
-        &self.job_name
-    }
-
     fn files_to_send(&self) -> Box<dyn Iterator<Item = FileMetadata> + Send> {
         let folder_files_to_send = self.working_dir.distribute_save_folder();
         let files = utils::read_folder_files(&folder_files_to_send);
         Box::new(files.into_iter().skip(1))
+    }
+}
+
+impl SendLogging for SenderFinalStore {
+    fn job_identifier(&self) -> JobSetIdentifier {
+        JobSetIdentifier::None
+    }
+    fn namespace(&self) -> &str {
+        "UNKNOWN"
+    }
+    fn batch_name(&self) -> &str {
+        "UNKNOWN"
+    }
+    fn job_name(&self) -> &str {
+        &self.job_name
+    }
+    fn node_meta(&self) -> &NodeMetadata {
+        &self.node_meta
     }
 }
 
@@ -57,13 +75,7 @@ impl NextState for SenderState<SenderFinalStore> {
             ..
         } = extra;
 
-        #[allow(unused_mut)]
-        let mut conn = conn.update_state();
-
-        // TODO: find how to include this in non-async code
-        //
-        //#[cfg(test)]
-        //assert!(conn.bytes_left().await == 0);
+        let conn = conn.update_state();
 
         ClientBuiltState {
             conn,
@@ -77,6 +89,7 @@ impl NextState for SenderState<SenderFinalStore> {
 /// state for a simple list of files to transfer
 pub(crate) struct FlatFileList {
     pub(crate) files: Vec<FileMetadata>,
+    pub(crate) node_meta: NodeMetadata,
 }
 
 impl NextState for SenderState<FlatFileList> {
@@ -89,9 +102,6 @@ impl NextState for SenderState<FlatFileList> {
 }
 
 impl FileSender for FlatFileList {
-    fn job_name(&self) -> &str {
-        "user_file_send"
-    }
     fn files_to_send(&self) -> Box<dyn Iterator<Item = FileMetadata> + Send> {
         warn!("enumerating files (flat send) and their destinations");
 
@@ -104,6 +114,24 @@ impl FileSender for FlatFileList {
         }
 
         Box::new(self.files.clone().into_iter())
+    }
+}
+
+impl SendLogging for FlatFileList {
+    fn job_identifier(&self) -> JobSetIdentifier {
+        JobSetIdentifier::None
+    }
+    fn namespace(&self) -> &str {
+        "UNKNOWN"
+    }
+    fn batch_name(&self) -> &str {
+        "UNKNOWN"
+    }
+    fn job_name(&self) -> &str {
+        "UNKNOWN"
+    }
+    fn node_meta(&self) -> &NodeMetadata {
+        &self.node_meta
     }
 }
 
@@ -140,10 +168,6 @@ impl NextState for SenderState<BuildingSender> {
 }
 
 impl FileSender for BuildingSender {
-    fn job_name(&self) -> &str {
-        "building_file_send"
-    }
-
     fn files_to_send(&self) -> Box<dyn Iterator<Item = FileMetadata> + Send> {
         let sendable_files = self.build_info.init.sendable_files(false);
         warn!("enumerating files (BUILDING) and their destinations");
@@ -157,6 +181,24 @@ impl FileSender for BuildingSender {
         }
 
         Box::new(sendable_files.into_iter())
+    }
+}
+
+impl SendLogging for BuildingSender {
+    fn job_identifier(&self) -> JobSetIdentifier {
+        self.build_info.identifier
+    }
+    fn namespace(&self) -> &str {
+        &self.build_info.namespace
+    }
+    fn batch_name(&self) -> &str {
+        &self.build_info.batch_name
+    }
+    fn job_name(&self) -> &str {
+        "BUILDING"
+    }
+    fn node_meta(&self) -> &NodeMetadata {
+        &self.common.node_meta
     }
 }
 
@@ -193,18 +235,32 @@ impl NextState for SenderState<ExecutingSender> {
 }
 
 impl FileSender for ExecutingSender {
-    fn job_name(&self) -> &str {
-        "building_file_send"
-    }
-
     fn files_to_send(&self) -> Box<dyn Iterator<Item = FileMetadata> + Send> {
         Box::new(self.run_info.task.sendable_files(false).into_iter())
     }
 }
 
+impl SendLogging for ExecutingSender {
+    fn job_identifier(&self) -> JobSetIdentifier {
+        self.run_info.identifier
+    }
+    fn namespace(&self) -> &str {
+        &self.run_info.namespace
+    }
+    fn batch_name(&self) -> &str {
+        &self.run_info.batch_name
+    }
+    fn job_name(&self) -> &str {
+        &self.run_info.task.name()
+    }
+    fn node_meta(&self) -> &NodeMetadata {
+        &self.common.node_meta
+    }
+}
+
 impl<T, NEXT, MARKER> Machine<SendFiles, SenderState<T>>
 where
-    T: FileSender,
+    T: FileSender + SendLogging,
     SenderState<T>: NextState<Marker = MARKER, Next = NEXT>,
     MARKER: Default,
 {
@@ -212,7 +268,12 @@ where
     ///
     /// if there is an error reading a file, that file will be logged but not sent. The
     /// only possible error from this function is if the TCP connection is cut.
-    #[instrument(skip(self), fields(job_name=self.state.extra.job_name()))]
+    #[instrument(skip(self), fields(
+        job_name=self.state.extra.job_name(),
+        node_meta=%self.state.extra.node_meta(),
+        namespace=self.state.extra.namespace(),
+        batch_name=self.state.extra.batch_name(),
+    ))]
     pub(crate) async fn send_files(mut self) -> Result<Machine<MARKER, NEXT>, (Self, ClientError)> {
         let job_name = self.state.extra.job_name();
         let files_to_send = self.state.extra.files_to_send();
@@ -311,6 +372,15 @@ where
         let msg = ClientMsg::FinishFiles;
         let tmp = self.state.conn.transport_data(&msg).await;
         throw_error_with_self!(tmp, self);
+
+        if self.state.conn.bytes_left().await != 0 {
+            error!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+            panic!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+        }
 
         let next_state = self.state.next_state();
         let machine = Machine::from_state(next_state);

--- a/src/protocol/uninit.rs
+++ b/src/protocol/uninit.rs
@@ -127,11 +127,17 @@ impl Machine<Uninit, ClientUninitState> {
             working_dir,
             cancel_addr,
         } = self.state;
-        #[allow(unused_mut)]
+
         let mut conn = conn.update_state();
 
-        #[cfg(test)]
-        assert!(conn.bytes_left().await == 0);
+        if conn.bytes_left().await != 0 {
+            error!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+            panic!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+        }
 
         debug!("moving client uninit -> prepare build");
         super::prepare_build::ClientPrepareBuildState {
@@ -221,11 +227,17 @@ impl Machine<Uninit, ServerUninitState> {
             self.state.common.node_meta
         );
         let ServerUninitState { conn, common } = self.state;
-        #[allow(unused_mut)]
+
         let mut conn = conn.update_state();
 
-        #[cfg(test)]
-        assert!(conn.bytes_left().await == 0);
+        if conn.bytes_left().await != 0 {
+            error!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+            panic!(
+                "connection was not empty - this is guaranteed to cause error in following steps!"
+            );
+        }
 
         super::prepare_build::ServerPrepareBuildState { conn, common }
     }

--- a/src/protocol/uninit.rs
+++ b/src/protocol/uninit.rs
@@ -129,15 +129,7 @@ impl Machine<Uninit, ClientUninitState> {
         } = self.state;
 
         let mut conn = conn.update_state();
-
-        if conn.bytes_left().await != 0 {
-            error!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-            panic!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-        }
+        super::assert_conn_empty(&mut conn).await;
 
         debug!("moving client uninit -> prepare build");
         super::prepare_build::ClientPrepareBuildState {
@@ -229,15 +221,7 @@ impl Machine<Uninit, ServerUninitState> {
         let ServerUninitState { conn, common } = self.state;
 
         let mut conn = conn.update_state();
-
-        if conn.bytes_left().await != 0 {
-            error!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-            panic!(
-                "connection was not empty - this is guaranteed to cause error in following steps!"
-            );
-        }
+        super::assert_conn_empty(&mut conn).await;
 
         super::prepare_build::ServerPrepareBuildState { conn, common }
     }

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 /// execute a query to pull files from a head node / server
 pub async fn pull(args: cli::Pull) -> Result<(), Error> {
     let config: config::Jobs<config::common::File> =
-        config::load_config(&args.job_file).map_err(error::PullErrorLocal::from)?;
+        config::load_config(&args.job_file, true).map_err(error::PullErrorLocal::from)?;
 
     let req = match args.filter {
         Some(cli::RegexFilter::Include { include }) => {

--- a/src/run_local.rs
+++ b/src/run_local.rs
@@ -14,7 +14,7 @@ pub async fn run_local(args: cli::Run) -> Result<(), RunErrorLocal> {
 
     create_required_dirs(&args, &working_dir).await?;
 
-    let config = config::load_config::<config::Jobs<config::common::File>>(&args.job_file)?;
+    let config = config::load_config::<config::Jobs<config::common::File>>(&args.job_file, true)?;
 
     let apptainer_config = match config {
         config::Jobs::Apptainer(app) => app,

--- a/src/server/job_pool.rs
+++ b/src/server/job_pool.rs
@@ -40,8 +40,12 @@ where
                             new_req.initialized_job,
                             new_req.capabilities,
                             &new_req.build_failures,
-                            new_req.node_meta,
+                            new_req.node_meta.clone(),
                         );
+
+                        // log all the paths, ensure they exist
+                        new_task.enumerate_paths(&new_req.node_meta);
+
                         new_req.tx.send(new_task).ok().unwrap();
                     }
                     // a job failed to execute on the node

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -26,7 +26,7 @@ use tokio::sync::{broadcast, mpsc};
 pub async fn server_command(server: cli::Server) -> Result<(), Error> {
     debug!("starting server");
 
-    let nodes_config = config::load_config::<config::Nodes>(&server.nodes_file)?;
+    let nodes_config = config::load_config::<config::Nodes>(&server.nodes_file, true)?;
     debug!("finished loading nodes config");
 
     if server.save_path.exists() && server.clean_output {

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -80,7 +80,9 @@ async fn run_all_jobs(
                 let (uninit, run_task_info) = send_files_err_state.into_uninit();
 
                 // return the task to the scheduler
-                let return_msg = server::JobRequest::DeadNode(run_task_info);
+                let dead_node =
+                    server::pool_data::DeadNode::new(run_task_info, uninit.node_meta().clone());
+                let return_msg = server::JobRequest::DeadNode(dead_node);
                 scheduler_tx
                     .send(return_msg)
                     .await
@@ -128,7 +130,9 @@ async fn execute_and_send_files(
 
             let (uninit, run_task_info) = execute.into_uninit();
 
-            let return_msg = server::JobRequest::DeadNode(run_task_info);
+            let dead_node =
+                server::pool_data::DeadNode::new(run_task_info, uninit.node_meta().clone());
+            let return_msg = server::JobRequest::DeadNode(dead_node);
             scheduler_tx
                 .send(return_msg)
                 .await
@@ -162,7 +166,9 @@ async fn execute_and_send_files(
                 run_task_info.batch_name,
             );
 
-            let return_msg = server::JobRequest::DeadNode(run_task_info);
+            let dead_node =
+                server::pool_data::DeadNode::new(run_task_info, uninit.node_meta().clone());
+            let return_msg = server::JobRequest::DeadNode(dead_node);
             scheduler_tx
                 .send(return_msg)
                 .await

--- a/src/server/pool_data.rs
+++ b/src/server/pool_data.rs
@@ -13,24 +13,22 @@ pub(crate) enum JobResponse {
 impl JobResponse {
     pub(crate) fn enumerate_paths(&self, meta: &NodeMetadata) {
         match &self {
-            Self::SetupOrRun(task_info) => {
-                enumerate_paths(meta, task_info)
-            }
-            Self::EmptyJobs => {
-            }
+            Self::SetupOrRun(task_info) => enumerate_paths(meta, task_info),
+            Self::EmptyJobs => {}
         }
     }
 }
 
-#[instrument(fields(
+#[instrument(
+    skip(node_meta, task_info)
+    fields(
     node_meta=%node_meta,
     namespace=task_info.namespace,
     batch_name=task_info.batch_name,
 ))]
 fn enumerate_paths(node_meta: &NodeMetadata, task_info: &TaskInfo) {
-
     fn print_file(file: &client::execute::FileMetadata) {
-        let exists = file.absolute_file_path.exists ();
+        let exists = file.absolute_file_path.exists();
 
         if exists {
             info!(

--- a/src/server/pool_data.rs
+++ b/src/server/pool_data.rs
@@ -10,12 +10,83 @@ pub(crate) enum JobResponse {
     EmptyJobs,
 }
 
+impl JobResponse {
+    pub(crate) fn enumerate_paths(&self, meta: &NodeMetadata) {
+        match &self {
+            Self::SetupOrRun(task_info) => {
+                enumerate_paths(meta, task_info)
+            }
+            Self::EmptyJobs => {
+            }
+        }
+    }
+}
+
+#[instrument(fields(
+    node_meta=%node_meta,
+    namespace=task_info.namespace,
+    batch_name=task_info.batch_name,
+))]
+fn enumerate_paths(node_meta: &NodeMetadata, task_info: &TaskInfo) {
+
+    fn print_file(file: &client::execute::FileMetadata) {
+        let exists = file.absolute_file_path.exists ();
+
+        if exists {
+            info!(
+                absolute_path = %file.absolute_file_path.display(),
+                relative_path = %file.relative_file_path.display(),
+                exists = exists
+            );
+        } else {
+            error!(
+                absolute_path = %file.absolute_file_path.display(),
+                relative_path = %file.relative_file_path.display(),
+                exists = exists
+            );
+        }
+    }
+
+    let mut files = Vec::new();
+
+    match &task_info.task {
+        JobOrInit::Job(job) => {
+            info!("enumerating all files required for job execution");
+            match job {
+                config::Job::Python(py) => {
+                    py.sendable_files(false, &mut files);
+                }
+                config::Job::Apptainer(app) => {
+                    app.sendable_files(false, &mut files);
+                }
+            }
+        }
+        JobOrInit::JobInit(init) => {
+            info!("enumerating all files required for job initialization");
+            match init {
+                config::Init::Python(py) => {
+                    py.sendable_files(false, &mut files);
+                }
+                config::Init::Apptainer(app) => {
+                    app.sendable_files(false, &mut files);
+                }
+            }
+        }
+    }
+
+    for file in &files {
+        print_file(file);
+    }
+
+    info!("finished enumerating all files required for job / build");
+}
+
 #[derive(derive_more::From)]
 pub(crate) enum JobRequest {
     NewJob(NewJobRequest),
     /// a client failed a keepalive check while it was
     /// executing
-    DeadNode(RunTaskInfo),
+    DeadNode(DeadNode),
     AddJobSet(config::Jobs<config::common::HashedFile>),
     QueryRemainingJobs(RemainingJobsQuery),
     CancelBatchByName(CancelBatchQuery),
@@ -23,14 +94,22 @@ pub(crate) enum JobRequest {
     FinishJob(FinishJob),
 }
 
-#[derive(PartialEq)]
+//#[derive(PartialEq)]
 pub(crate) struct FinishJob {
     pub(crate) ident: JobSetIdentifier,
     pub(crate) job_name: String,
+    pub(crate) node_meta: NodeMetadata,
 }
 
 pub(crate) struct MarkBuildFailure {
     pub(crate) ident: JobSetIdentifier,
+    pub(crate) node_meta: NodeMetadata,
+}
+
+#[derive(derive_more::Constructor)]
+pub(crate) struct DeadNode {
+    pub(crate) task: RunTaskInfo,
+    pub(crate) node_meta: NodeMetadata,
 }
 
 pub(crate) struct NewJobRequest {
@@ -168,7 +247,7 @@ pub(crate) enum JobOrInit {
     JobInit(config::Init),
 }
 
-#[derive(Display, Clone, Debug, Serialize, Deserialize, Constructor)]
+#[derive(Display, Clone, Debug, Serialize, Deserialize, Constructor, PartialEq)]
 #[display(fmt = "{node_name} : {node_address}")]
 /// information about the compute node that is stored on the scheduling server.
 ///

--- a/src/slurm.rs
+++ b/src/slurm.rs
@@ -9,7 +9,7 @@ pub fn slurm(args: cli::Slurm) -> Result<(), error::Slurm> {
     //
     // load the config files
     //
-    let jobs = config::load_config::<config::Jobs<config::common::File>>(&args.jobs)?;
+    let jobs = config::load_config::<config::Jobs<config::common::File>>(&args.jobs, true)?;
 
     if jobs.len_jobs() == 0 {
         return Err(error::Slurm::NoJobs);

--- a/tests/many_jobsets_single_sif.rs
+++ b/tests/many_jobsets_single_sif.rs
@@ -1,0 +1,236 @@
+use distribute::cli::Run;
+use distribute::cli::Slurm;
+
+use distribute::cli::Add;
+use distribute::cli::Client;
+use distribute::cli::Server;
+use distribute::cli::ServerStatus;
+
+use std::fs;
+use std::net::IpAddr;
+use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn many_jobsets_single_sif() {
+    println!("starting many_jobsets_single_sif");
+    if true {
+        distribute::logger();
+    }
+
+    assert_eq!(
+        PathBuf::from("./tests/apptainer_local/apptainer_local.sif").exists(),
+        true,
+        "you need to run ./tests/apptainer_local/build.sh before executing tests"
+    );
+
+    let server_port = 9981;
+    // this is the port in the corresponding distribute-nodes.yaml file for this job
+    let client_port = 9967;
+    let keepalive_port = 9968;
+    let cancel_port = 9969;
+    let addr: IpAddr = [0, 0, 0, 0].into();
+
+    let dir: PathBuf = "./tests/many_jobsets_single_sif".into();
+    let nodes_file: PathBuf = dir.join("distribute-nodes.yaml");
+    let server_save_dir = dir.join("server_save_dir");
+    let server_temp_dir = dir.join("server_temp_dir");
+    let client_workdir = dir.join("workdir");
+    let configs_dir = dir.join("configs");
+
+    fs::remove_dir_all(&server_save_dir).ok();
+    fs::remove_dir_all(&server_temp_dir).ok();
+    fs::remove_dir_all(&client_workdir).ok();
+    fs::remove_dir_all(&configs_dir).ok();
+
+    fs::create_dir(&server_save_dir).unwrap();
+    fs::create_dir(&server_temp_dir).unwrap();
+    fs::create_dir(&client_workdir).unwrap();
+    fs::create_dir(&configs_dir).unwrap();
+
+    // start up a client
+    // the port comes from distribute-nodes.yaml
+    let client = Client::new(
+        client_workdir.clone(),
+        client_port,
+        keepalive_port,
+        cancel_port,
+        "./output.log".into(),
+    );
+    tokio::spawn(async move {
+        println!("starting the client");
+        distribute::client_command(client).await.unwrap();
+        println!("client has exited");
+    });
+
+    thread::sleep(Duration::from_secs(1));
+
+    let server = Server::new(
+        nodes_file,
+        server_save_dir.clone(),
+        server_temp_dir.clone(),
+        server_port,
+        false,
+        None,
+    );
+
+    // start the server
+    tokio::task::spawn(async move {
+        println!("starting server");
+        distribute::server_command(server).await.unwrap();
+        println!("server has exited");
+    });
+
+    // let the server start up for a few seconds
+    thread::sleep(Duration::from_secs(1));
+
+    let num_batches = 3;
+
+    let config_paths = write_many_batch_configs(
+        "./tests/apptainer_local/distribute-jobs.yaml".into(),
+        configs_dir.clone(),
+        num_batches,
+    );
+
+    dbg!(&config_paths);
+
+    //
+    // Add a bunch of jobs to the server, all using the same sif file
+    //
+
+    for config_path in &config_paths {
+        // configure a job to send off to the server
+        let run = Add::new(
+            config_path.to_owned(),
+            server_port,
+            addr,
+            false,
+            false,
+        );
+        distribute::add(run).await.unwrap();
+    }
+
+    // we know that it takes around 10 seconds for a job to get scheduled to
+    // a node from the sleep section is src/node.rs - therefore we wait:
+    // 10 seconds - job to get scheduled
+    // 10 seconds - file to get sent
+    // 5 * num_batches  seconds - all jobs to finish
+
+    //let status = ServerStatus::new(server_port, addr);
+    //let jobs = distribute::get_current_jobs(&status).await.unwrap();
+
+    // check that all batches are available on the server 
+    //dbg!(jobs.len());
+    //dbg!(&jobs);
+    //assert!(jobs.len() == num_batches);
+
+    thread::sleep(Duration::from_secs(10 + 10 + 5 * (num_batches as u64)));
+
+    let status = ServerStatus::new(server_port, addr);
+    let jobs = distribute::get_current_jobs(&status).await.unwrap();
+
+    // print out some logs on what jobs are still not scheduled
+    distribute::server_status(status).await.unwrap();
+
+    dbg!(&jobs);
+    dbg!(&jobs.len());
+
+    // in the vector of all the job sets added (1 at most in length),
+    // we should have no jobs set information remaining because all the jobs
+    // were deallocated
+    assert_eq!(jobs.len(), 0);
+
+    //// directory tree should be this:
+    //// check_deallocate_jobs
+    ////     ├── distribute-nodes.yaml
+    ////     ├── server_save_dir
+    ////     │   └── some_namespace
+    ////     │       └── some_batch
+    ////     │           ├── job_1
+    ////     │           │   ├── job_1_output.txt
+    ////     │           │   └── simulated_output.txt
+    ////     │           └── job_2
+    ////     │               ├── job_2_output.txt
+    ////     │               └── simulated_output.txt
+
+    //let batch = server_save_dir.join("some_namespace/some_batch");
+    //assert_eq!(
+    //    batch.join("job_1/simulated_output.txt").exists(),
+    //    true,
+    //    "missing job 1 simulation output"
+    //);
+    //assert_eq!(
+    //    batch.join("job_2/simulated_output.txt").exists(),
+    //    true,
+    //    "missing job 2 simulation output"
+    //);
+
+    //// we should also have output files for the jobs that we ran
+    //assert_eq!(
+    //    batch.join("job_1/job_1_output.txt").exists(),
+    //    true,
+    //    "missing job 1 output file"
+    //);
+    //assert_eq!(
+    //    batch.join("job_2/job_2_output.txt").exists(),
+    //    true,
+    //    "missing job 2 output file"
+    //);
+
+    //// we should not have output files from jobs we did not run
+    //assert_eq!(
+    //    batch.join("job_1/job_2_output.txt").exists(),
+    //    false,
+    //    "output for job 2 exists in job 1"
+    //);
+    //assert_eq!(
+    //    batch.join("job_2/job_1_output.txt").exists(),
+    //    false,
+    //    "output for job 1 exists in job 2"
+    //);
+
+    fs::remove_dir_all(&server_save_dir).ok();
+    fs::remove_dir_all(&server_temp_dir).ok();
+    fs::remove_dir_all(&client_workdir).ok();
+    fs::remove_dir_all(&configs_dir).ok();
+}
+
+/// Generate a bunch of config files based on a input config file identical
+/// to the template w/ a change of the batch name
+fn write_many_batch_configs(
+    base_config: PathBuf,
+    config_dir: PathBuf,
+    num_configs: usize,
+) -> Vec<PathBuf> {
+    use distribute::NormalizePaths;
+
+    let mut out = Vec::new();
+
+    let relative_path = PathBuf::from("./tests/apptainer_local/").canonicalize().unwrap();
+
+    let mut main_config =
+        distribute::load_config::<distribute::Jobs<distribute::common::File>>(&base_config, false)
+            .unwrap();
+
+    main_config.normalize_paths(relative_path);
+
+    let config: distribute::ApptainerConfig<_> = match main_config {
+        distribute::Jobs::Python(_) => unreachable!(),
+        distribute::Jobs::Apptainer(app) => app,
+    };
+
+    for i in 0..num_configs {
+        let config_name = format!("distribute-jobs-{i:02}.yaml");
+        let config_path = config_dir.join(config_name);
+        let file = fs::File::create(&config_path).unwrap();
+        let mut cfg = config.clone();
+
+        cfg.meta_mut().set_batch_name(format!("batch_{i:02}"));
+        cfg.to_writer(file).unwrap();
+
+        out.push(config_path);
+    }
+
+    out
+}

--- a/tests/many_jobsets_single_sif.rs
+++ b/tests/many_jobsets_single_sif.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn many_jobsets_single_sif() {
     println!("starting many_jobsets_single_sif");
-    if true {
+    if false {
         distribute::logger();
     }
 
@@ -85,7 +85,7 @@ async fn many_jobsets_single_sif() {
     // let the server start up for a few seconds
     thread::sleep(Duration::from_secs(1));
 
-    let num_batches = 3;
+    let num_batches = 10;
 
     let config_paths = write_many_batch_configs(
         "./tests/apptainer_local/distribute-jobs.yaml".into(),

--- a/tests/many_jobsets_single_sif/distribute-jobs.yaml
+++ b/tests/many_jobsets_single_sif/distribute-jobs.yaml
@@ -1,0 +1,21 @@
+---
+meta:
+  batch_name: some_batch
+  namespace: some_namespace
+  capabilities: []
+apptainer:
+  initialize:
+    sif: 
+      path: apptainer_local.sif
+    required_mounts:
+      - /dir1
+      - /dir2
+  jobs:
+    - name: job_1
+      required_files:
+        - path: input_1.txt
+          alias: input.txt
+    - name: job_2
+      required_files:
+        - path: input_2.txt
+          alias: input.txt

--- a/tests/many_jobsets_single_sif/distribute-nodes.yaml
+++ b/tests/many_jobsets_single_sif/distribute-nodes.yaml
@@ -1,0 +1,6 @@
+nodes:
+  - ip: "0.0.0.0"
+    transport_port: 9967
+    keepalive_port: 9968
+    capabilities: []
+    name: "testname"


### PR DESCRIPTION
* Logging for every scheduler query
* Better logging for the receiving of files at the cost of some additional verbosity for non-server-client communications
* Test to ensure that identical config file setups with different metadata sections hash to different file names so that files from a different set are not randomly deleted
* File output logs do not have ANSI terminal escape codes making them far easier to read & grep
* Integration test to ensure that many tests with the same jobs w/ slightly different metadata sections finish successfully